### PR TITLE
qt5: update to 5.15.1

### DIFF
--- a/aqua/qt5/Portfile
+++ b/aqua/qt5/Portfile
@@ -13,7 +13,7 @@ license             {LGPL-3 GPL-3 OpenSSLException}
 
 homepage            https://www.qt.io
 
-version             5.14.2
+version             5.15.1
 set middle_name     everywhere
 if { ${subport} eq "${name}-qtwebkit" ||
      ${subport} eq "${name}-qtwebkit-examples" ||
@@ -131,9 +131,9 @@ foreach {qt_test_name qt_test_info} [array get available_qt_versions] {
 array set modules {
     qt3d {
         {
-            820677fc9e200ff4c364a958ce3ab9cbdef5cfbe
-            9da82f1cc4b7d416d31ec96224c59d221473a48f6e579eef978f7d2e3932c674
-            81576496
+            9d468dd213a206fe0135bbf82814256a3bf81f14 \
+            29aac2c38b6b2fb1e7d54829ff8b4c9aae12a70ffab9707c7388f1e134dd9411
+            81919836
         }
         ""
         "port:assimp"
@@ -146,9 +146,9 @@ array set modules {
     }
     qtbase {
         {
-            103d9c42037393a8c3e6467c9bd1eab447d3c4fb
-            48b9e79220941665a9dd827548c6428f7aa3052ccba8f4f7e039a94aa1d2b28a
-            49865752
+            ee72124f5c407fd6172e63d4a84a9999419144fe \
+            33960404d579675b7210de103ed06a72613bfc4305443e278e2d32a3eb1f3d8c
+            50153132
         }
         ""
         "port:zlib port:libpng port:jpeg port:freetype path:bin/dbus-daemon:dbus path:lib/pkgconfig/glib-2.0.pc:glib2 port:icu port:pcre2 port:harfbuzz port:double-conversion port:zstd"
@@ -156,14 +156,14 @@ array set modules {
         {"Qt Core" "Qt GUI" "Qt Network" "Qt SQL" "Qt Test" "Qt Widgets" "Qt Concurrent" "Qt D-Bus" "Qt OpenGL" "Qt Platform Headers" "Qt Print Support" "Qt XML"}
         ""
         "variant overrides: "
-        "revision 1"
+        "revision 0"
         "License: "
     }
     qtcharts {
         {
-            20e8775cfda1b7bf6aabd08f8bbd3cd68dd36461
-            adb25203ea748d886cc3d8993c20def702115eccea311594592058134ba83bb7
-            4250508
+            f16aa8fc7ffa5b24ab3a7afc786d2590394eae57 \
+            a59efbf095bf8a62c29f6fe90a3e943bbc7583d1d2fed16681675b923c45ef3b
+            4251664
         }
         ""
         ""
@@ -176,9 +176,9 @@ array set modules {
     }
     qtconnectivity {
         {
-            2ec5b5213dcf6850313c611e3c7891084c94f7a3
-            abe67b3e3a775e2a2e27c62a5391f37007ffbe72bce58b96116995616cfcbc28
-            2804940
+            d56c2d184801c7a8b43769128279f75a561ab9d1 \
+            53c30039d4f2301a1a66c646690436e1f8cce0a3fd212ca0783f346a115d8016
+            2814984
         }
         ""
         ""
@@ -191,9 +191,9 @@ array set modules {
     }
     qtdatavis3d {
         {
-            89cd6d2fbde42f13661ea72b8964148111aa930c
-            723c03db2d2805b1be4ca534ac7bc867a1a21894d33a7e9261a382f3fa9d0e20
-            5190800
+            81de56d932a7f7449525bdbc149e91e7fc967696 \
+            89ed596ea452a8dd8223d094690606bcccc92962776584aceefcc13f56538c06
+            5191624
         }
         ""
         ""
@@ -206,9 +206,9 @@ array set modules {
     }
     qtdeclarative {
         {
-            b5af85ffa37ef1a4b9c51432cb02b80fd0766a7e
-            a3c4617adc9760347c93d2eb6c25d22f620cd22f44afa0494eb499a805831650
-            21305980
+            3b6559902139290947b8a9ebffd5897782598f21 \
+            7e30f0ccba61f9d71720b91d7f7523c23677f23cd96065cb71df1b0df329d768
+            21558724
         }
         "port:python27"
         ""
@@ -221,9 +221,9 @@ array set modules {
     }
     qtdoc {
         {
-            98f0f1c8f7b93eb902703a9f94691e81cbe1bf53
-            5a55cdb55af35eb222d06179567851c175f24a3732f7dee5be073df4a893172b
-            5736088
+            99321fa707c7ef4b131d5af913ab5d74a3050718 \
+            f71b37b050f530c066fab49acb8dacf3d6c99cdef6af1f5ef6c1cbf6d3f87451
+            5745776
         }
         ""
         ""
@@ -236,9 +236,9 @@ array set modules {
     }
     qtgamepad {
         {
-            182f7e03463dfb48587ae247476d277ac9c76ed2
-            f77daadb4755cf760e11812264259fb103396fd1b06df1e06b5df162081c8d03
-            386940
+            26e046b75f34e1585c2dfa83ad92fd55454bb3ea \
+            87ffcd5cd5588a0114b7ec76d9de5d486154a0833cd11f400c414d07402eb452
+            387004
         }
         ""
         "port:libsdl2"
@@ -251,9 +251,9 @@ array set modules {
     }
     qtgraphicaleffects {
         {
-            f54cbd0cffa95ff512e83a4f6a102b077675a954
-            487a7f858244a08264363733055a8cf8b00e77c658c5608cc462817d15e4b50f
-            14040880
+            0f0212a0bfea527d54eb44be6b6a92bd900cf3ba \
+            f4a4d3e1c6d8b0b200b6759ebb615344275957d56d2ef6a33641f853120466d1
+            14040940
         }
         ""
         ""
@@ -266,9 +266,9 @@ array set modules {
     }
     qtimageformats {
         {
-            cf1d51d69a297601e7c2fe6198cdd2238b54b57e
-            733eca0165c15e046b106039c989dac7f6bc2ecf215396d965ed065369264f8c
-            1805208
+            a4a52e7bd9cd929db007bb05e57e89b5a4d5e917 \
+            75e72b4c11df97af3ff64ed26df16864ce1220a1cc730e49074ab9d72f658568
+            1807112
         }
         ""
         "port:jasper port:libmng port:tiff port:webp"
@@ -281,9 +281,9 @@ array set modules {
     }
     qtlocation {
         {
-            cbea15ad47dff58f1c6d8b06c18b1202e46ce312
-            c37708bc396f6dac397b49a6a268d5edb39e1c8296ca2337ce9e80bde04775cc
-            6120852
+            a1206c03ad548fe969e3ab29841f1b2ad0de7011 \
+            093af763a70d126c4b9f6a22ebf8218fe95dc0151e40666b2389fdf55c9f1a2c
+            6553252
         }
         ""
         "port:icu port:zlib"
@@ -291,14 +291,14 @@ array set modules {
         {"Qt Location" "Qt Positioning"}
         ""
         "variant overrides: "
-        "revision 1"
+        "revision 0"
         "License: "
     }
     qtlottie  {
         {
-            8d40131f11f5c5b521da22e92f68f52921526c39
-            55d1392dc92cbec11263084360075dc5fc3fdc25c1969adfbdec84299b285978
-            82572
+            cbf31be172a4e6ba5efd1a29052b78cb01b4ea5f \
+            845987860c7990035a7cd9a0e7581d210f786e551882df8b5be69f08987f2ba0
+            82456
         }
         ""
         ""
@@ -311,9 +311,9 @@ array set modules {
     }
     qtmacextras {
         {
-            96f1a74a2f4e9a493dfa36188aacb39832756309
-            d12587b46c84a7822194fc3ccf46f7c18ff3b31566d3dde4f5fe772f1d8776e5
-            69360
+            6401ccf4409055cf514a13fc6a757fb6761ca1a6 \
+            6bbcbb95bd854fc5325257c797379bd66cd5f0601ccca2ab6a2af5610d113f62
+            69308
         }
         ""
         ""
@@ -326,9 +326,9 @@ array set modules {
     }
     qtmultimedia {
         {
-            b531cc7ca42cf9737064ea2eee8f162a12720467
-            7acd8ede6835314206e407b35b668f0add67544577fb51fe67afb03137fb9fe9
-            3793964
+            f94035d6c01dfcc1d9bf6849b35f2eb236f556a6 \
+            ed6e75bec9c98559c0fbc91ff746185b1e1845139b2c7a5a843e1e8880697d99
+            3825940
         }
         ""
         ""
@@ -341,9 +341,9 @@ array set modules {
     }
     qtnetworkauth {
         {
-            65591f9e8ae006806d8e9e54af13b4336cb9df72
-            4f00513dd18598487d02187b80b54c669662cf8a8f2573858c7f9282d7b9265e
-            141424
+            6dd3fb0c0deb9af3d08b688c583579799a80b159 \
+            e5e37ae8f842e4bb66f1e719d8585ef71bc13c79545054fcd26072cd58e4d4c2
+            141416
         }
         ""
         ""
@@ -356,9 +356,9 @@ array set modules {
     }
     qtpurchasing {
         {
-            5338fe693067c469b40d936df49154f7714a5c82
-            69b087001e8fcec5bb49ca333d5f44e6b7eb09f76421dc792fc9cd76dee9e851
-            208664
+            78dd3f22fd8ad2a1c7da495dc113a318ca83639b \
+            be88908243a16fc0a1b22d656b7b651690b757329ea9fd2236998004fbd57f75
+            208716
         }
         ""
         ""
@@ -371,9 +371,9 @@ array set modules {
     }
     qtquick3d {
         {
-            f18e90ba83a610ea5bd9cde0d38b37fc6d5352e2
-            0640696d501f2b0bf57f64e98f30bfa3e1cc19c11c0e05e43d4fdb0d20488b2e
-            61600360
+            3efb8c4b5f7a0e4a79abdc311841a913aa2ed088 \
+            a18ce5549f9d7a3c313385733eae7fe7b501d74a450c2515f887c671a9fa3457
+            55758364
         }
         ""
         "port:assimp"
@@ -386,9 +386,9 @@ array set modules {
     }
     qtquickcontrols {
         {
-            d41a9f259939edc2e6c59c694a34479d59b929e0
-            d55def1dd4ee1250bd6a4e76849f4e362368b6411c2216d5f669c761216d4461
-            5981560
+            179a2052ff15209bf5b690ef9906fadd375fe605 \
+            0172f88779305aae57f3842538e91361ae9bc5ca2275ee5ce9d455309f0f2c7e
+            5983304
         }
         ""
         ""
@@ -401,9 +401,9 @@ array set modules {
     }
     qtquickcontrols2 {
         {
-            574218f9a41523a6686d2ba82b5d3499fe9a4032
-            faf7d349d8f4a8db36cd3c62a5724bcf689300f2fdb7dc1ea034392aab981560
-            8153752
+            094922e9ffe32586d6e027c67fb1dfd8ebf85f15 \
+            e902b3baf9fe02a5bd675fc71118e282bb6a128c94f45be6f65d7d6db991f2af
+            8282444
         }
         ""
         ""
@@ -416,9 +416,9 @@ array set modules {
     }
     qtquicktimeline {
         {
-            72f266b59b090542b8fc61a3f825c738699dae44
-            83a45d0998cbc77f8094854a477ab1ac0838ae7fd822563d995df40149893a9e
-            102636
+            d0339d8d89a6a923f592b3c965ad2835980e4832 \
+            15665d489a6a29ff406a5fe2b4ac14ab102fb6e43864e115432be065da073cca
+            102556
         }
         ""
         ""
@@ -431,9 +431,9 @@ array set modules {
     }
     qtremoteobjects {
         {
-            b9ccaa5ad821d4d0a1b33e079584b073fc46f45f
-            a6a601c4f4aab6fe41a462dae57033819f697e3317240a382cee45c08be614d6
-            376740
+            f87ead5842f0eb88555bc3746e870ecac11dba40 \
+            71b58fdac717645fa6f8b6ecb79b86841c540838877d100fabe2381175c4154e
+            374640
         }
         ""
         ""
@@ -446,9 +446,9 @@ array set modules {
     }
     qtscript {
         {
-            707919651feb565d8154a77f48ba662bc376aca0
-            e9fd487ccb3cbf00e86b0b803aa79e9f6bbe7a337b8e97d069e040c3e0789bfe
-            2654528
+            4e8dc0f21cb5a9650635386500a2223cb62bb2ba \
+            0a62152835363a9cc20558d0c2953ec03426324138578baa18fc2cc4d62b18ca
+            2663232
         }
         ""
         ""
@@ -461,9 +461,9 @@ array set modules {
     }
     qtscxml {
         {
-            4885374fdebcf5068d3e20b37fa150ef9efe1e33
-            030cea352a56074f577200f967ef37c959b2767127de61f766f59b0d99763790
-            433268
+            884784239246a37c4138994ec2bdf60da5307ded \
+            2289f8c1b51ac368cc0ba8a6a987b44d2c97b43697b00e64582e43afedffcd2b
+            434168
         }
         ""
         ""
@@ -476,9 +476,9 @@ array set modules {
     }
     qtsensors {
         {
-            27c509504b76ac4405520e7d6c626d10ce43c563
-            bccfca6910b0383d8f65823496ff5011abed2fa8fd446b4b27333d0fd7bb8c61
-            2050616
+            43c60127b0f5dafe38ed2b2381912b02da796b6f \
+            8096b9ffe737434f9564432048f622f6be795619da4e1ed362ce26dddb2cea00
+            2057232
         }
         ""
         ""
@@ -491,9 +491,9 @@ array set modules {
     }
     qtserialbus {
         {
-            7fc5f35f154361e41192e5ff58689441722f2927
-            0b7762175a649a40c4dd619c5de61d772235dc86099343278e2c3229d0836a91
-            349808
+            1feb7f736a68c15dc2c405fa949986d6e26c2813 \
+            9ee220826032ae1f8e68d9ec7dddc10ddc4c2e0a771d34009ae307b07eeca751
+            356308
         }
         ""
         ""
@@ -506,9 +506,9 @@ array set modules {
     }
     qtserialport {
         {
-            92c5f0baad1e3b5f0379dee563760b6aba1e69f9
-            a6d977dd723ad4d3368b5163691405b8852f809974a96ec54103494e834aea21
-            316492
+            87c458a64bff4791e4b0e31ddff7906dd92c865e \
+            3605130148936ec3fd632bc13c70873d74ef9a8a0b28b17f3be917d848cfb8d9
+            321472
         }
         ""
         ""
@@ -521,9 +521,9 @@ array set modules {
     }
     qtspeech {
         {
-            3b15521943828941234338329fff1e14369388ef
-            5e9e8ea62f0207ba894df1e136df0af9fc5443c7817d28c39f0ea2bbae9ec6da
-            101100
+            c98bf09b66b95520960b268427d16e307d2c0c55 \
+            7d2a5f7cf653d711de249ce4689959866d2381c625ced7ed4db7c8baaa140edc
+            101772
         }
         ""
         ""
@@ -536,9 +536,9 @@ array set modules {
     }
     qtsvg {
         {
-            ca837b599d53b818ce416309e6a13c30ee9c9062
-            c7d7faa01a3e7a6e4d38fafcec5529a488258218749779e6fa0e09a21173b5a1
-            1880100
+            745102db8cb931d7cdb125fc430dbe54813f2f17 \
+            308160223c0bd7492d56fb5d7b7f705bfb130947ac065bf39280ec6d7cbe4f6a
+            1885556
         }
         ""
         ""
@@ -551,12 +551,12 @@ array set modules {
     }
     qttools {
         {
-            35f435253529301da39d017931da4f3c1778fd04
-            5bb0cf7832b88eb6bc9d4289f98307eb14b16a453ad6cf42cca13c4fe1a053c5
-            8815020
+            bfb5ab4aa54e444d629ba13470548849a3cd426d \
+            c98ee5f0f980bf68cbf0c94d62434816a92441733de50bd9adbe9b9055f03498
+            8901096
         }
         ""
-        "port:clang-9.0"
+        ""
         "qtbase qtdeclarative"
         {"Qt Designer" "Qt Help" "Qt UI Tools"}
         ""
@@ -566,9 +566,9 @@ array set modules {
     }
     qttranslations {
         {
-            abc83f4522d6daa92cb7f7463c3559baab29db61
-            2088ebee9f5dd0336c9fd11436899a95b7ce0141ce072290de1e8f315d82d1a6
-            1348684
+            905e8b5eee1aede00247bf891c339ae28a0f490b \
+            46e0c0e3a511fbcc803a4146204062e47f6ed43b34d98a3c27372a03b8746bd8
+            1419252
         }
         ""
         ""
@@ -581,9 +581,9 @@ array set modules {
     }
     qtvirtualkeyboard {
         {
-            a876b77ab3f1aff8387dbfb3fb3cd4904e674c46
-            364f3338563e617e7c964a37170b415b546c5f82965e781271f9dada3e3868d7
-            10957372
+            f08e57b6e97d247a961f5c1c6b6ed9c6d2226a1c \
+            8cf62c4f0662f3f4b52b32f9d2cf1845a636d3df663869a98d47dfe748eb1c3d
+            10969980
         }
         ""
         "port:hunspell"
@@ -596,9 +596,9 @@ array set modules {
     }
     qtwebchannel {
         {
-            13b2305239dad6c64409362ff31ce719560f7e82
-            7d1dc8441523638c3d455c7d408ec65aebc073acab80e24063865f929231f874
-            202592
+            0608a8eb4186d6efbf8d675a20097c523967eca7 \
+            7f3ef8e626d932bbc121810661a62ece3955ab982340676a19001417e2faf9fc
+            208872
         }
         ""
         ""
@@ -611,9 +611,9 @@ array set modules {
     }
     qtwebengine {
         {
-            00b8e62bc9cc7348dfa2f92bab8f9e30f83b4cfa
-            e169d6a75d8c397e04f843bc1b9585950fb9a001255cd18d6293f66fa8a6c947
-            242467568
+            b522ef3b7f3124c67a460256147f5529211379ca \
+            f903e98fe3cd717161252710125fce011cf882ced96c24968b0c38811fbefdf2
+            278488056
         }
         "port:python27 port:py27-ply path:bin/ninja:ninja port:gperf port:bison port:flex"
         "port:fontconfig port:dbus port:harfbuzz path:lib/pkgconfig/glib-2.0.pc:glib2 port:zlib port:minizip port:libevent port:libxml2 port:jsoncpp port:protobuf3-cpp port:poppler port:pulseaudio port:icu path:lib/libavcodec.dylib:ffmpeg port:libopus port:webp port:libpng port:lcms2 port:freetype port:re2 port:snappy"
@@ -621,14 +621,14 @@ array set modules {
         {"Qt WebEngine"}
         "very large and relatively new"
         "variant overrides: "
-        "revision 1"
+        "revision 0"
         "License: "
     }
     qtwebglplugin {
         {
-            8a30662273570df0d24effcf354b4dd516642523
-            eb4118910b65d03d8448658ac1646e860d337e59b82d6575beda21824e313417
-            74140
+            0164f8a785667d0552eb7ac56be136ff1443b505 \
+            63c76f384252090694a8a2a8a18441d4fc4502d688cc4ac798a0d27b2221733c
+            74080
         }
         ""
         ""
@@ -671,9 +671,9 @@ array set modules {
     }
     qtwebsockets {
         {
-            f26dc43353b8ee9117f0be2c8984c6ccee450528
-            f06e62b18313fe1b40a35566e79645de4a8e7ac9f7717d1d98a06c5b49afca84
-            252820
+            7ed494399464c0ed9f1092055ec383fba52af551 \
+            5f30053a0a794676ce7d7521f6b789409cc449a7e90cab547d871fc07a61dd7e
+            258908
         }
         ""
         ""
@@ -686,9 +686,9 @@ array set modules {
     }
     qtwebview {
         {
-            62e14451ac6a35f2ad6324a1711fbf740f3c730c
-            c61f9213ee84fd7408898c0194468208ffb51af9d257e87e6b53daf24f65ff4b
-            132840
+            c40bbcf84fc5902f2f354fe8deee57c2640dbadb \
+            426852a3f569da82aa84dfd7f06c6aeb06488a927b66342a612401b41392b260
+            133392
         }
         ""
         ""
@@ -701,9 +701,9 @@ array set modules {
     }
     qtxmlpatterns {
         {
-            0ddfeb4d31bf4855aa866febeb877b18aea8464e
-            219a876665345e3801baff71f31f30f5495c1cb9ab23fbbd27602632c80fcfb7
-            1404028
+            c51bdd7aca48ba08414c471902b1c5a7dbbae50c \
+            6859d440ce662f3679ce483ebb5a552b619a32517cb1a52a38f967b377857745
+            1415888
         }
         ""
         ""
@@ -924,6 +924,10 @@ foreach {module module_info} [array get modules] {
             # See e.g. octave
             # See the files mkspecs/features/qt_module.prf and qmake/generators/makefile.cpp
             patchfiles-append patch-pc_files.diff
+
+            # fix build where "backtrace_from_fp" is not defined
+            # this patch is specific to version 5.15
+            patchfiles-append patch-qt515-highsierra1.diff
 
             # find the Rez program
             patchfiles-append patch-find_rez.diff
@@ -1551,8 +1555,8 @@ foreach {module module_info} [array get modules] {
                 # do not opportunistically find MacPorts libraries (e.g. X11 libraries)
                 patchfiles-append patch-qtwebengine_tests.diff
 
-                # chromium/build/mac/find_sdk.py expects the SDK version (mac_sdk_min) in Major.Minor format
-                # If Patch version is provided it fails with "Exception: No Major.Minor.Patch+ SDK found"
+                # chromium/build/mac/find_sdk.py is written for macOS
+                # 10.* versioning; tweak to find 1[0-9].*
                 patchfiles-append patch-qtwebengine_sdk.diff
 
                 # see https://trac.macports.org/ticket/60978

--- a/aqua/qt5/files/patch-qt515-highsierra1.diff
+++ b/aqua/qt5/files/patch-qt515-highsierra1.diff
@@ -1,0 +1,23 @@
+--- src/corelib/kernel/qcore_mac.mm.orig
++++ src/corelib/kernel/qcore_mac.mm
+@@ -262,16 +262,20 @@
+ 
+ #ifdef QT_DEBUG
+     void *poolFrame = nullptr;
++#if MAC_OS_X_VERSION_MAX_ALLOWED >= 101400
+     if (__builtin_available(macOS 10.14, iOS 12.0, tvOS 12.0, watchOS 5.0, *)) {
+         void *frame;
+         if (backtrace_from_fp(__builtin_frame_address(0), &frame, 1))
+             poolFrame = frame;
+     } else {
++#endif
+         static const int maxFrames = 3;
+         void *callstack[maxFrames];
+         if (backtrace(callstack, maxFrames) == maxFrames)
+             poolFrame = callstack[maxFrames - 1];
++#if MAC_OS_X_VERSION_MAX_ALLOWED >= 101400
+     }
++#endif
+ 
+     if (poolFrame) {
+         Dl_info info;

--- a/aqua/qt5/files/patch-qtwebengine_sdk.diff
+++ b/aqua/qt5/files/patch-qtwebengine_sdk.diff
@@ -1,11 +1,11 @@
---- src/buildtools/config/mac_osx.pri.orig	2020-03-24 02:16:30.000000000 -0700
-+++ src/buildtools/config/mac_osx.pri	2020-04-27 18:56:04.000000000 -0700
-@@ -28,7 +28,7 @@
-     clang_base_path=\"$${QMAKE_CLANG_DIR}\" \
-     clang_use_chrome_plugins=false \
-     mac_deployment_target=\"$${QMAKE_MACOSX_DEPLOYMENT_TARGET}\" \
--    mac_sdk_min=\"$${QMAKE_MAC_SDK_VERSION}\" \
-+    mac_sdk_min=\"$$section(QMAKE_MAC_SDK_VERSION, ".", 0, 1)\" \
-     use_external_popup_menu=false
- 
- qtConfig(webengine-spellchecker) {
+--- src/3rdparty/chromium/build/mac/find_sdk.py.orig
++++ src/3rdparty/chromium/build/mac/find_sdk.py
+@@ -88,7 +88,7 @@
+     raise SdkError('Install Xcode, launch it, accept the license ' +
+       'agreement, and run `sudo xcode-select -s /path/to/Xcode.app` ' +
+       'to continue.')
+-  sdks = [re.findall('^MacOSX(10\.\d+)\.sdk$', s) for s in os.listdir(sdk_dir)]
++  sdks = [re.findall('^MacOSX(1[0-9]\.\d+)\.sdk$', s) for s in os.listdir(sdk_dir)]
+   sdks = [s[0] for s in sdks if s]  # [['10.5'], ['10.6']] => ['10.5', '10.6']
+   sdks = [s for s in sdks  # ['10.5', '10.6'] => ['10.6']
+           if parse_version(s) >= parse_version(min_sdk_version)]

--- a/aqua/qt5/files/patch-qtwebengine_tests.diff
+++ b/aqua/qt5/files/patch-qtwebengine_tests.diff
@@ -1,6 +1,6 @@
---- src/buildtools/configure.json.orig	2019-12-03 00:18:02.000000000 -0700
-+++ src/buildtools/configure.json	2020-01-02 09:29:39.000000000 -0700
-@@ -34,25 +34,25 @@
+--- src/buildtools/configure.json.orig
++++ src/buildtools/configure.json
+@@ -35,25 +35,25 @@
          "webengine-xcomposite": {
              "label": "xcomposite",
              "sources": [
@@ -30,7 +30,7 @@
              ]
          },
          "webengine-nss": {
-@@ -64,7 +64,7 @@
+@@ -65,7 +65,7 @@
          "webengine-x11" : {
              "label" : "x11",
              "sources": [
@@ -39,33 +39,3 @@
              ]
          },
          "webengine-glib": {
-@@ -211,25 +211,25 @@
-         "webengine-xcomposite": {
-             "label": "xcomposite",
-             "sources": [
--                { "type": "pkgConfig", "args": "xcomposite" }
-+                { "type": "pkgConfig", "args": "xcomposite-fail-on-macports" }
-             ]
-         },
-         "webengine-xcursor": {
-             "label": "xcursor",
-             "sources": [
--                { "type": "pkgConfig", "args": "xcursor" }
-+                { "type": "pkgConfig", "args": "xcursor-fail-on-macports" }
-             ]
-         },
-         "webengine-xi": {
-             "label": "xi",
-             "sources": [
--                { "type": "pkgConfig", "args": "xi" }
-+                { "type": "pkgConfig", "args": "xi-fail-on-macports" }
-             ]
-         },
-         "webengine-xtst": {
-             "label": "xtst",
-             "sources": [
--                { "type": "pkgConfig", "args": "xtst" }
-+                { "type": "pkgConfig", "args": "xtst-fail-on-macports" }
-             ]
-         },
-         "webengine-ffmpeg": {

--- a/aqua/qt5/files/patch-rule_bison.py.diff
+++ b/aqua/qt5/files/patch-rule_bison.py.diff
@@ -1,8 +1,6 @@
-diff --git a/old/rule_bison.py b/src/3rdparty/chromium/third_party/blink/renderer/build/scripts/rule_bison.py
-index f75e25f..6d96b7e 100755
---- src/3rdparty/chromium/third_party/blink/renderer/build/scripts/rule_bison.py
+--- src/3rdparty/chromium/third_party/blink/renderer/build/scripts/rule_bison.py.orig
 +++ src/3rdparty/chromium/third_party/blink/renderer/build/scripts/rule_bison.py
-@@ -101,7 +101,7 @@ assert outputHTmp != None
+@@ -114,7 +114,7 @@
  outputHFile = open(outputHTmp)
  outputHContents = outputHFile.read()
  outputHFile.close()


### PR DESCRIPTION
Fixes: https://trac.macports.org/ticket/61103

NOTE: qt5-qtwebengine doesn't work with macOS 11 yet, even with the SDK patch provided here. Given how few folks use this port, and how many use the other qt5-* ports, let's get those in place & come back to this one as need be down the road.

#### Description

<!-- Note: it is best to make pull requests from a branch rather than from master -->

###### Type(s)
<!-- update (title contains ": U(u)pdate to"), submission (new Portfile) and CVE Identifiers are auto-detected, replace [ ] with [x] to select -->

- [ ] bugfix
- [ ] enhancement
- [ ] security fix

###### Tested on
<!-- Triple-click and copy the next line and paste it into your shell. It will copy your OS and Xcode version to the clipboard. Paste it here replacing this section.
printf "%s\n" "macOS $(sw_vers -productVersion) $(sw_vers -buildVersion)" "$(xcodebuild -version|awk 'NR==1{x=$0}END{print x" "$NF}')"|tee /dev/tty|pbcopy
-->
macOS x.y
Xcode x.y

###### Verification <!-- (delete not applicable items) -->
Have you

- [ ] followed our [Commit Message Guidelines](https://trac.macports.org/wiki/CommitMessages)?
- [ ] squashed and [minimized your commits](https://guide.macports.org/#project.github)?
- [ ] checked that there aren't other open [pull requests](https://github.com/macports/macports-ports/pulls) for the same change?
- [ ] referenced existing tickets on [Trac](https://trac.macports.org/wiki/Tickets) with full URL? <!-- Please don't open a new Trac ticket if you are submitting a pull request. -->
- [ ] checked your Portfile with `port lint`?
- [ ] tried existing tests with `sudo port test`?
- [ ] tried a full install with `sudo port -vst install`?
- [ ] tested basic functionality of all binary files?

<!-- Use "skip notification" (surrounded with []) to avoid notifying maintainers -->
